### PR TITLE
Fix exit status on signal command failures

### DIFF
--- a/dwmblocks/dwmblocks.c
+++ b/dwmblocks/dwmblocks.c
@@ -191,7 +191,7 @@ void sighandler(int signum, siginfo_t *si, void *ucontext) {
             setsid();
             execvp(cmd[0], cmd);
             perror(cmd[0]);
-            exit(EXIT_SUCCESS);
+            exit(EXIT_FAILURE);
         }
     } else {
         if (sig == 10) {


### PR DESCRIPTION
## Summary
- Ensure dwmblocks exits with failure when a signaled command cannot exec

## Testing
- `make CFLAGS='-DNO_X -pedantic -Wall -Wno-deprecated-declarations -Os' LDFLAGS=''`
- `./dwmblocks -p & # remove /bin/sh and send signal via helper to trigger exec failure`

------
https://chatgpt.com/codex/tasks/task_e_68a52d2ba89883239be137c94f4ae6d1