### PR TITLE
Enable and start GDM in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,8 +63,9 @@ sudo make clean install
 cd "$SCRIPT_DIR"
 
 # Enable and start GDM
-echo "Enabling GDM..."
-systemctl enable gdm
+# Using --now to start the service immediately
+echo "Enabling and starting GDM..."
+systemctl enable --now gdm
 
 # Prompt for Dotfile Installation
 read -p "Do you want to install custom DWM dotfiles? (yes/no): " dotfiles_choice


### PR DESCRIPTION
## Summary
- Enable and start GDM during installation by using `systemctl enable --now`
- Document the immediate start of GDM in script comments and output

## Testing
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a52d2b30648323b7e5521451054c6a