### PR TITLE
Fix typo in IPC header comment

### DIFF
--- a/dwm/patch/ipc/ipc.h
+++ b/dwm/patch/ipc/ipc.h
@@ -274,7 +274,7 @@ void ipc_focused_state_change_event(const int mon_num, const Window client_id,
                                     const ClientState *old_state,
                                     const ClientState *new_state);
 /**
- * Check to see if an event has occured and call the *_change_event functions
+ * Check to see if an event has occurred and call the *_change_event functions
  * accordingly
  *
  * @param mons Address of Monitor pointing to start of linked list


### PR DESCRIPTION
## Summary
- fix spelling in IPC event documentation comment

## Testing
- `make -C dwm` *(fails: X11/extensions/Xinerama.h: No such file or directory)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a52d2b496c8323bd4887e170622828