### PR TITLE
Fix uninitialized sigaction mask in dwmblocks

### DIFF
--- a/dwmblocks/dwmblocks.c
+++ b/dwmblocks/dwmblocks.c
@@ -103,6 +103,7 @@ void getsigcmds(unsigned int signal) {
 
 void setupsignals() {
     struct sigaction sa = { .sa_sigaction = sighandler, .sa_flags = SA_SIGINFO };
+    sigemptyset(&sa.sa_mask);
 #ifndef __OpenBSD__
     /* initialize all real time signals with dummy handler */
     for (int i = SIGRTMIN; i <= SIGRTMAX; i++) {


### PR DESCRIPTION
## Summary
- Initialize `sigaction` mask before registering signal handlers to avoid undefined behavior

## Testing
- `cd dwmblocks && make clean >/tmp/make_clean.log && tail -n 20 /tmp/make_clean.log`
- `cd dwmblocks && make >/tmp/make.log && tail -n 20 /tmp/make.log`


------
https://chatgpt.com/codex/tasks/task_e_68a52c2816dc8323af2dd48d38b6057d