### PR TITLE
Avoid starting GDM during installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,10 +62,10 @@ cd "$DWM_DIR"
 sudo make clean install
 cd "$SCRIPT_DIR"
 
-# Enable and start GDM
-# Using --now to start the service immediately
-echo "Enabling and starting GDM..."
-systemctl enable --now gdm
+# Enable GDM
+# The service will start automatically on the next boot
+echo "Enabling GDM..."
+systemctl enable gdm
 
 # Prompt for Dotfile Installation
 read -p "Do you want to install custom DWM dotfiles? (yes/no): " dotfiles_choice


### PR DESCRIPTION
## Summary
- Update GDM setup to only enable the service instead of enabling and starting it
- Adjust related comments and user messages

## Testing
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a535ffc6a48323b93e823f0a451596